### PR TITLE
Improve navigation links and cleanup

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,73 +1,75 @@
-'use client';
-import Link from 'next/link';
-import Image from 'next/image';
-import linkedinLogo from './linkedin-logo.png';
-import { useState } from 'react';
+"use client";
+import Link from "next/link";
+import Image from "next/image";
+import linkedinLogo from "./linkedin-logo.png";
+import { useState } from "react";
 // Add this line at the end of your header.tsx file
-
-
 
 export default function Header() {
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
   const toggleDropdown = () => setIsDropdownVisible(!isDropdownVisible);
 
   const links = [
-    { name: 'About', path: '/#about' },
-    { name: 'Skills', path: '/#skills' },
-    { name: 'Experience', path: '/experience' },
-    { name: 'Contact', path: '/#contact' },
+    { name: "About", path: "/#about" },
+    { name: "Skills", path: "/#skills" },
+    { name: "Experience", path: "/experience" },
+    { name: "Contact", path: "/#contact" },
   ];
 
   const projectsDropdown = [
-    { name: 'GearGuroo: Dynamic Bike Gear Recommendation', path: '/projects/gearguroo' },
-    { name: 'Vise Stop: Machining Project', path: '/projects/vise' },
+    {
+      name: "GearGuroo: Dynamic Bike Gear Recommendation",
+      path: "/projects/gearguroo",
+    },
+    { name: "Vise Stop: Machining Project", path: "/projects/vise" },
     // Add more projects as needed
   ];
 
   return (
-    <nav className="flex w-full justify-center py-2 select-none pt-6 font-light md:px-28 md:pb-2">
-      <div className="container flex flex-col md:flex-row items-center justify-between">
+    <nav className="flex w-full select-none justify-center py-2 pt-6 font-light md:px-28 md:pb-2">
+      <div className="container flex flex-col items-center justify-between md:flex-row">
         {/* Logo */}
-        <Link href="/" passHref legacyBehavior>
-          <a className="text-5xl drop-shadow-2xl cursor-pointer">
-            <Image
-              src="/newzlogo.png"
-              alt="Zack DeParle"
-              width={40}
-              height={40}
-              objectFit="contain"
-            />
-          </a>
+        <Link href="/" className="cursor-pointer text-5xl drop-shadow-2xl">
+          <Image
+            src="/newzlogo.png"
+            alt="Zack DeParle"
+            width={40}
+            height={40}
+            style={{ objectFit: "contain" }}
+          />
         </Link>
         {/* Navigation Links */}
         <div className="nav-links flex flex-grow items-center justify-center gap-x-8 text-xs md:text-base">
           {links.map((link) => (
-            <Link key={link.name} href={link.path} legacyBehavior>
-              <a className="cursor-pointer hover:text-blue-500 transition-colors duration-200">
-                {link.name}
-              </a>
+            <Link
+              key={link.name}
+              href={link.path}
+              className="cursor-pointer transition-colors duration-200 hover:text-blue-500"
+            >
+              {link.name}
             </Link>
           ))}
           <div className="relative">
-            <Link href="/projects" legacyBehavior>
-              <a
-                onMouseOver={() => setIsDropdownVisible(true)}
-                onTouchStart={toggleDropdown}
-                className="cursor-pointer hover:text-blue-500 transition-colors duration-200"
-              >
-                Projects
-              </a>
+            <Link
+              href="/projects"
+              onMouseOver={() => setIsDropdownVisible(true)}
+              onTouchStart={toggleDropdown}
+              className="cursor-pointer transition-colors duration-200 hover:text-blue-500"
+            >
+              Projects
             </Link>
             {isDropdownVisible && (
               <div
-                className="absolute bg-white shadow-md mt-2 py-2 rounded"
+                className="absolute mt-2 rounded bg-white py-2 shadow-md"
                 onMouseLeave={() => setIsDropdownVisible(false)}
               >
                 {projectsDropdown.map((project) => (
-                  <Link key={project.name} href={project.path} legacyBehavior>
-                    <a className="block px-4 py-2 text-sm hover:bg-gray-200">
-                      {project.name}
-                    </a>
+                  <Link
+                    key={project.name}
+                    href={project.path}
+                    className="block px-4 py-2 text-sm hover:bg-gray-200"
+                  >
+                    {project.name}
                   </Link>
                 ))}
               </div>
@@ -76,17 +78,20 @@ export default function Header() {
         </div>
         {/* LinkedIn Button */}
         <div className="flex items-center justify-end">
-          <Link href="https://www.linkedin.com/in/zachary-deparle" legacyBehavior>
-            <a target="_blank" rel="noopener noreferrer" className="ml-4">
-              <Image
-                src={linkedinLogo}
-                alt="LinkedIn"
-                width={40}
-                height={40}
-                objectFit="contain"
-                className="cursor-pointer"
-              />
-            </a>
+          <Link
+            href="https://www.linkedin.com/in/zachary-deparle"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-4"
+          >
+            <Image
+              src={linkedinLogo}
+              alt="LinkedIn"
+              width={40}
+              height={40}
+              style={{ objectFit: "contain" }}
+              className="cursor-pointer"
+            />
           </Link>
         </div>
       </div>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,18 +1,9 @@
 // pages/_app.tsx
-import '../styles/globals.css';
+import "../styles/globals.css";
 import Layout from "@/components/layout";
-import type { AppProps } from 'next/app';
-import { useEffect} from 'react';
-import confetti from 'canvas-confetti';
+import type { AppProps } from "next/app";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  useEffect(()=>{
-    confetti({
-      particleCount:100,
-      spread:70,
-      origin: {y : 0.6}
-    })
-  },[]);
   return (
     <Layout>
       <Component {...pageProps} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,16 +8,17 @@ import Link from "next/link";
 export default function Home() {
   return (
     <>
-      
       <Hero />
       <About />
       <Skills />
       {/* Update this section for the projects link */}
-      <section className="text-center my-8">
-      <Link href="/projects"legacyBehavior>
-          <a className="largeEmojiButton" aria-label="View Projects">
-            🏗️ {"Projects"}
-          </a>
+      <section className="my-8 text-center">
+        <Link
+          href="/projects"
+          className="largeEmojiButton"
+          aria-label="View Projects"
+        >
+          🏗️ {"Projects"}
         </Link>
       </section>
       <Contact />

--- a/src/sections/hero.tsx
+++ b/src/sections/hero.tsx
@@ -2,7 +2,7 @@ import ContactList from "@/components/contact-list";
 import MotionText from "@/components/motion-text";
 import MotionDiv from "@/components/motion-div";
 
-export default function hero() {
+export default function Hero() {
   return (
     <section className="my-8 flex flex-col items-center justify-center">
       <h1 className="mb-4 text-[1.4rem] md:text-[2rem]">
@@ -37,7 +37,8 @@ export default function hero() {
         </MotionDiv>
         <MotionDiv delayOffset={1.4}>
           <p>
-            I'm currently a Mechanical Engineering and Computer Science student at Duke University, passionate about technology and engineering.
+            I'm currently a Mechanical Engineering and Computer Science student
+            at Duke University, passionate about technology and engineering.
           </p>
         </MotionDiv>
       </div>


### PR DESCRIPTION
## Summary
- remove legacy `Link` patterns
- simplify main layout and hero component
- drop confetti side-effect on page load

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864bd99c4e4832d984db5a14e661573