### PR TITLE
Improve portfolio theme

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -26,7 +26,7 @@ export default function Header() {
   ];
 
   return (
-    <nav className="flex w-full select-none justify-center py-2 pt-6 font-light md:px-28 md:pb-2">
+    <nav className="flex w-full select-none justify-center bg-gradient-to-r from-primary to-indigo-500 py-4 font-light text-primary-foreground shadow">
       <div className="container flex flex-col items-center justify-between md:flex-row">
         {/* Logo */}
         <Link href="/" className="cursor-pointer text-5xl drop-shadow-2xl">
@@ -44,7 +44,7 @@ export default function Header() {
             <Link
               key={link.name}
               href={link.path}
-              className="cursor-pointer transition-colors duration-200 hover:text-blue-500"
+              className="cursor-pointer transition-colors duration-200 text-primary-foreground hover:text-white/80"
             >
               {link.name}
             </Link>
@@ -54,20 +54,20 @@ export default function Header() {
               href="/projects"
               onMouseOver={() => setIsDropdownVisible(true)}
               onTouchStart={toggleDropdown}
-              className="cursor-pointer transition-colors duration-200 hover:text-blue-500"
+              className="cursor-pointer transition-colors duration-200 text-primary-foreground hover:text-white/80"
             >
               Projects
             </Link>
             {isDropdownVisible && (
               <div
-                className="absolute mt-2 rounded bg-white py-2 shadow-md"
+                className="absolute mt-2 rounded bg-background py-2 shadow-lg"
                 onMouseLeave={() => setIsDropdownVisible(false)}
               >
                 {projectsDropdown.map((project) => (
                   <Link
                     key={project.name}
                     href={project.path}
-                    className="block px-4 py-2 text-sm hover:bg-gray-200"
+                    className="block px-4 py-2 text-sm text-foreground hover:bg-muted"
                   >
                     {project.name}
                   </Link>
@@ -90,7 +90,7 @@ export default function Header() {
               width={40}
               height={40}
               style={{ objectFit: "contain" }}
-              className="cursor-pointer"
+              className="cursor-pointer hover:opacity-80"
             />
           </Link>
         </div>

--- a/src/sections/about.tsx
+++ b/src/sections/about.tsx
@@ -4,13 +4,13 @@ export default function about() {
   return (
     <section
       id="about"
-      className="mx-auto my-16 flex flex-col items-center justify-center gap-4 px-2 md:my-20  md:max-w-full lg:flex-row lg:items-start lg:gap-16"
+      className="mx-auto my-16 flex flex-col items-center justify-center gap-4 rounded-xl bg-card px-6 py-10 shadow lg:flex-row lg:items-start lg:gap-16"
     >
       <div className="order-2 lg:order-1 lg:w-2/3">
         <MotionDiv delayOffset={0.2}>
           <h2 className="mb-3 w-full text-center md:mb-6">About Me</h2>
         </MotionDiv>
-        <article className="flex flex-col gap-4">
+        <article className="flex flex-col gap-4 text-lg leading-relaxed">
           <MotionDiv delayOffset={0.4}>
             <p>
               Hello, I'm Zachary (Zack) DeParle. I'm a
@@ -48,7 +48,7 @@ export default function about() {
           <img
             src="/photo.jpeg"
             alt="photo"
-            className="w-[350px] min-w-[300px] rounded-xl transition-all hover:rotate-3 hover:scale-105"
+            className="w-[350px] min-w-[300px] rounded-xl ring-4 ring-primary/30 transition-all hover:rotate-3 hover:scale-105"
           />
         </MotionDiv>
       </div>

--- a/src/sections/contact.tsx
+++ b/src/sections/contact.tsx
@@ -5,7 +5,7 @@ const Contact = () => {
   return (
     <section
       id="contact"
-      className="mx-auto my-16 flex flex-col items-center justify-center gap-4 px-2 md:my-20 md:max-w-full"
+      className="mx-auto my-16 flex flex-col items-center justify-center gap-6 rounded-xl bg-card px-6 py-12 shadow md:max-w-full"
     >
       
 
@@ -14,10 +14,14 @@ const Contact = () => {
 
         {/* Email Button */}
         <MotionDiv delayOffset={0.5}>
-  <a href="mailto:zachary.deparle@gmail.com" className={styles.contactButton} aria-label="Email Me">
-    📧 {"Email Me!"}
-  </a>
-</MotionDiv>
+          <a
+            href="mailto:zachary.deparle@gmail.com"
+            className={styles.contactButton}
+            aria-label="Email Me"
+          >
+            📧 {"Email Me!"}
+          </a>
+        </MotionDiv>
 
 
        

--- a/src/sections/hero.tsx
+++ b/src/sections/hero.tsx
@@ -4,8 +4,8 @@ import MotionDiv from "@/components/motion-div";
 
 export default function Hero() {
   return (
-    <section className="my-8 flex flex-col items-center justify-center">
-      <h1 className="mb-4 text-[1.4rem] md:text-[2rem]">
+    <section className="my-8 flex flex-col items-center justify-center rounded-xl bg-gradient-to-br from-primary to-indigo-600 py-16 text-primary-foreground shadow-lg">
+      <h1 className="mb-6 text-3xl font-semibold md:text-5xl">
         <MotionText delayOffset={0}>Hi, I'm Zack DeParle! 👋</MotionText>
       </h1>
       <div className="overflow-hidden rounded-full p-3 md:p-4">
@@ -22,21 +22,21 @@ export default function Hero() {
           </video>
         </MotionDiv>
       </div>
-      <h1>
+      <h1 className="text-2xl font-medium md:text-3xl">
         <MotionDiv delayOffset={0.8}>🎨Designer🎨</MotionDiv>
       </h1>
-      <h1>
+      <h1 className="text-2xl font-medium md:text-3xl">
         <MotionDiv delayOffset={1}>🔨Builder🔨</MotionDiv>
       </h1>
-      <h1>
+      <h1 className="text-2xl font-medium md:text-3xl">
         <MotionDiv delayOffset={1.2}>💡Problem Solver💡</MotionDiv>
       </h1>
       <div className="my-12 flex w-full flex-col gap-2 text-center lg:w-[50%]">
         <MotionDiv delayOffset={1.2}>
-          <p>Welcome to my personal page!</p>
+          <p className="text-lg md:text-xl">Welcome to my personal page!</p>
         </MotionDiv>
         <MotionDiv delayOffset={1.4}>
-          <p>
+          <p className="text-lg md:text-xl">
             I'm currently a Mechanical Engineering and Computer Science student
             at Duke University, passionate about technology and engineering.
           </p>

--- a/src/sections/skills.tsx
+++ b/src/sections/skills.tsx
@@ -156,12 +156,12 @@ export default function Skills() {
 
 function SkillCard({ icon, name }: { icon: StaticImageData; name: string }) {
   return (
-    <div className="group rounded-xl border-none p-5 text-center shadow-none">
+    <div className="group rounded-xl bg-card p-5 text-center shadow transition-transform hover:-translate-y-1 hover:shadow-lg">
       <div className="flex flex-col items-center gap-2">
         <div className="flex h-16 w-16 items-center justify-center">
           <Image src={icon} alt={name} priority />
         </div>
-        <p>{name}</p>
+        <p className="font-medium">{name}</p>
       </div>
     </div>
   );

--- a/src/styles/contact.module.css
+++ b/src/styles/contact.module.css
@@ -1,15 +1,15 @@
 .contactButton {
-  font-size: 3rem; /* Increased size for the emoji */
+  font-size: 3rem;
   display: inline-block;
   padding: 20px;
-  border: none;
-  background: transparent;
-  cursor: pointer;
+  border-radius: 9999px;
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
   text-decoration: none;
-  color: inherit;
-  transition: transform 0.2s;
+  transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .contactButton:hover {
-  transform: scale(1.1);
+  transform: scale(1.05);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
 }

--- a/src/styles/experience.module.css
+++ b/src/styles/experience.module.css
@@ -5,7 +5,7 @@
   padding: 20px;
   max-width: 1200px; /* Maximum width of the content */
   margin: 0 auto; /* Center the content */
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', sans-serif;
 }
 
 /* Navigation styles */
@@ -42,7 +42,7 @@
 
 /* Section styles */
 .experienceSection {
-  background-color: #fff; /* White background for each section */
+  background-color: hsl(var(--card));
   border-radius: 8px; /* Rounded corners for the card-like sections */
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Subtle shadow for depth */
   padding: 40px; /* Padding inside each section */
@@ -64,7 +64,7 @@
 
 .titleContainer h2 {
   font-size: 1.5rem; /* Adjust the size according to your design */
-  color: #1d1d1f; /* Dark grey color for titles */
+  color: hsl(var(--foreground));
 }
 
 .titleContainer img {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -7,32 +9,32 @@
 @layer base {
   :root {
     /* Light Mode Colors */
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --background: 220 14% 96%;
+    --foreground: 222 47% 11%;
 
     /* Card Colors */
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 222 47% 11%;
 
     /* Popover Colors */
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover-foreground: 222 47% 11%;
 
     /* Primary Colors */
-    --primary: 222.2 47.4% 11.2%;
+    --primary: 217 91% 60%;
     --primary-foreground: 210 40% 98%;
 
     /* Secondary Colors */
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 222 12% 44%;
+    --secondary-foreground: 210 40% 98%;
 
     /* Muted Colors */
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted: 215 24% 95%;
+    --muted-foreground: 222 9% 50%;
 
     /* Accent Colors */
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 217 91% 60%;
+    --accent-foreground: 210 40% 98%;
 
     /* Destructive Colors */
     --destructive: 0 84.2% 60.2%;
@@ -49,32 +51,32 @@
 
   /* Dark Mode Colors */
   .dark {
-    --background: 222.2 84% 4.9%;
+    --background: 222 47% 11%;
     --foreground: 210 40% 98%;
 
-    --card: 222.2 84% 4.9%;
+    --card: 222 47% 11%;
     --card-foreground: 210 40% 98%;
 
-    --popover: 222.2 84% 4.9%;
+    --popover: 222 47% 11%;
     --popover-foreground: 210 40% 98%;
 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 217 91% 60%;
+    --primary-foreground: 210 40% 98%;
 
-    --secondary: 217.2 32.6% 17.5%;
+    --secondary: 218 23% 16%;
     --secondary-foreground: 210 40% 98%;
 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted: 218 23% 24%;
+    --muted-foreground: 210 31% 80%;
 
-    --accent: 217.2 32.6% 17.5%;
+    --accent: 217 91% 60%;
     --accent-foreground: 210 40% 98%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
+    --border: 218 23% 24%;
+    --input: 218 23% 24%;
     --ring: 212.7 26.8% 83.9%;
   }
 }
@@ -85,7 +87,7 @@
     @apply scroll-smooth border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,9 @@ module.exports = {
       },
     },
     extend: {
+      fontFamily: {
+        sans: ["Inter", "ui-sans-serif", "system-ui", "sans-serif"],
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## Summary
- modernize site colors and fonts
- redesign hero with gradient, refined text
- apply card styling to sections and skill cards
- style contact button and header navigation
- tweak experience section styles

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864c31d3a88832d860e2079eaf6a4da